### PR TITLE
fix(#24) matchPathsを修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
         "*"
       ],
       "matchPaths" :[
-        "frontend/package.json"
+        "package.json"
       ],
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
matchPathsがモノレポ時代のままでルールが効いていなかったため、修正

Close #24 